### PR TITLE
Upgraded documentation to reflect PHP 7.1, MariaDB 10.1, and entrada-1x-me.localhost

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh		text eol=lf

--- a/docs/administrator/application-server.md
+++ b/docs/administrator/application-server.md
@@ -68,7 +68,7 @@ The hostnames that will be referenced throughout this document will be `entrada.
         touch /home/production/.ssh/authorized_keys
         chown -R production:production /home/production/.ssh
         chmod 700 /home/production/.ssh
-        chmod 644 /home/production/.ssh/authorized_keys
+        chmod 600 /home/production/.ssh/authorized_keys
 
 12. Add all developers' SSH public keys (i.e. `cat ~/.ssh/id_rsa.pub`) that are allowed to deploy Entrada to your production environment to the new `authorized_keys` file.
 
@@ -86,7 +86,7 @@ The hostnames that will be referenced throughout this document will be `entrada.
         touch /home/staging/.ssh/authorized_keys
         chown -R staging:staging /home/staging/.ssh
         chmod 700 /home/staging/.ssh
-        chmod 644 /home/staging/.ssh/authorized_keys
+        chmod 600 /home/staging/.ssh/authorized_keys
 
 15. Add all developers' SSH public keys (i.e. `cat ~/.ssh/id_rsa.pub`) that are allowed to deploy Entrada to your staging environment to the new `authorized_keys` file.
 
@@ -99,6 +99,7 @@ The hostnames that will be referenced throughout this document will be `entrada.
         mkdir /var/www/vhosts/entrada.med.university.edu/storage/app
         mkdir /var/www/vhosts/entrada.med.university.edu/storage/app/public
         mkdir /var/www/vhosts/entrada.med.university.edu/storage/cache
+        mkdir /var/www/vhosts/entrada.med.university.edu/storage/cbme-uploads
         mkdir /var/www/vhosts/entrada.med.university.edu/storage/community-discussions
         mkdir /var/www/vhosts/entrada.med.university.edu/storage/community-galleries
         mkdir /var/www/vhosts/entrada.med.university.edu/storage/community-shares
@@ -127,6 +128,7 @@ The hostnames that will be referenced throughout this document will be `entrada.
         mkdir /var/www/vhosts/staging.med.university.edu/storage/app
         mkdir /var/www/vhosts/staging.med.university.edu/storage/app/public
         mkdir /var/www/vhosts/staging.med.university.edu/storage/cache
+        mkdir /var/www/vhosts/staging.med.university.edu/storage/cbme-uploads
         mkdir /var/www/vhosts/staging.med.university.edu/storage/community-discussions
         mkdir /var/www/vhosts/staging.med.university.edu/storage/community-galleries
         mkdir /var/www/vhosts/staging.med.university.edu/storage/community-shares
@@ -207,15 +209,14 @@ The hostnames that will be referenced throughout this document will be `entrada.
         # This will limit what information Apache reveals about itself.
         ServerTokens Prod
         ServerSignature Off
-        
+
         <VirtualHost *:80>
             ServerName entrada.med.university.edu
             ServerAdmin sysadmin@med.university.edu
             DocumentRoot /var/www/vhosts/entrada.med.university.edu/current/www-root
             <Directory "/var/www/vhosts/entrada.med.university.edu/current/www-root">
                 Options FollowSymLinks
-                Order allow,deny
-                Allow from all
+                Require all granted
                 AllowOverride all
             </Directory>
         </VirtualHost>
@@ -235,8 +236,7 @@ The hostnames that will be referenced throughout this document will be `entrada.
             DocumentRoot /var/www/vhosts/entrada.med.university.edu/current/www-root
             <Directory "/var/www/vhosts/entrada.med.university.edu/current/www-root">
                 Options FollowSymLinks
-                Order allow,deny
-                Allow from all
+                Require all granted
                 AllowOverride all
             </Directory>
         </VirtualHost>
@@ -246,8 +246,7 @@ The hostnames that will be referenced throughout this document will be `entrada.
             DocumentRoot /var/www/vhosts/staging.med.university.edu/current/www-root
             <Directory "/var/www/vhosts/staging.med.university.edu/current/www-root">
                 Options FollowSymLinks
-                Order allow,deny
-                Allow from all
+                Require all granted
                 AllowOverride all
             </Directory>
         </VirtualHost>
@@ -267,8 +266,7 @@ The hostnames that will be referenced throughout this document will be `entrada.
             DocumentRoot /var/www/vhosts/staging.med.university.edu/current/www-root
             <Directory "/var/www/vhosts/staging.med.university.edu/current/www-root">
                 Options FollowSymLinks
-                Order allow,deny
-                Allow from all
+                Require all granted
                 AllowOverride all
             </Directory>
         </VirtualHost>

--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -80,20 +80,20 @@ GRANT ALL ON entrada_clerkship.* TO 'entrada'@'localhost';
 To begin, clone the Entrada ME repository into a web-accessible directory or new virtual host on your computer:
 ```
 cd ~/Sites
-git clone git@github.com:EntradaProject/entrada-1x-me.git entrada-1x-me.dev
+git clone git@github.com:EntradaProject/entrada-1x-me.git
 ```
 
 ### Setting Up for Development
 
 Ensure that you have the develop branch checked out, and install Composer as well as our dependencies:
 ```
-cd entrada-1x-me.dev
+cd entrada-1x-me
 git checkout develop
 curl -sS https://getcomposer.org/installer | php
 php composer.phar update
 ```
 
-Now visit your Entrada installation in your web-browser to proceed: http://entrada-1x-me.dev
+Now visit your Entrada installation in your web-browser to proceed: http://entrada-1x-me.localhost
 
 ## Deploying Entrada
 
@@ -117,11 +117,11 @@ sudo gem install gnm-caplock
 
 #### Deployment
 
-This example assumes that your deployment directory is located at `~/Sites/entrada-1x-me.dev/deployment`. Your deployment recipe exists within the `config/deploy.rb` directory. Please make sure that this file accurately reflects your hostnames and Git repository location.
+This example assumes that your deployment directory is located at `~/Sites/entrada-1x-me/deployment`. Your deployment recipe exists within the `config/deploy.rb` directory. Please make sure that this file accurately reflects your hostnames and Git repository location.
 
 To deploy a release, use the terminal and navigate to the deployment directory
 ```
-cd ~/Sites/entrada-1x-me.dev/deployment
+cd ~/Sites/entrada-1x-me/deployment
 # deploy to staging
 cap staging deploy
 # deploy to production

--- a/docs/developer/quickstart.md
+++ b/docs/developer/quickstart.md
@@ -31,7 +31,7 @@ Pay special attention to note of the bolded words above: migration, model, publi
 
 ### Let's Begin
 
-Open the `~/Sites/entrada-1x-me.dev` folder using PhpStorm or whatever IDE/Editor you have selected. Ensure that you set the tab size in your editor to 4 spaces as the tab character will not be accepted. For more information on coding standards visit the [Coding Standards](standards/) section.
+Open the `~/Sites/entrada-1x-me` folder using PhpStorm or whatever IDE/Editor you have selected. Ensure that you set the tab size in your editor to 4 spaces as the tab character will not be accepted. For more information on coding standards visit the [Coding Standards](standards/) section.
 
 #### 1. Create a New Database Migration
 
@@ -178,7 +178,7 @@ Entrada does not use a typical MVC pattern as you would recognize from framework
 
 Entrada's `.htaccess` file contains `mod_rewrite` rules that pipe the majority of requests through the `index.php` and `admin.php` files. The `index.php` file is used to display **public modules**, whereas the `admin.php` file is used to display **admin modules**.
 
-One significant difference between most MVC frameworks and Entrada is that our request routing is entirely automatic vs. being manually defined in a routes file. For example, if you visit [http://entrada-1x-me.dev/profile/gradebook/assignments](http://entrada-1x-me.dev/profile/gradebook/assignments) in your browser, Entrada will load the `www-root/core/modules/public/profile/gradebook/assignments/index.inc.php` file.
+One significant difference between most MVC frameworks and Entrada is that our request routing is entirely automatic vs. being manually defined in a routes file. For example, if you visit [http://entrada-1x-me.localhost/profile/gradebook/assignments](http://entrada-1x-me.localhost/profile/gradebook/assignments) in your browser, Entrada will load the `www-root/core/modules/public/profile/gradebook/assignments/index.inc.php` file.
  
  For a more thorough overview of this information please see the [Directory Structure](overview/#directory-structure) section within Overview. 
  
@@ -814,7 +814,7 @@ Within `www-root/core/modules/admin/sandbox/index.inc.php` place the following c
 
 A view helper allows you to create a single block of reusable code that can be displayed in many places. There are quite a few presently undocumented options and features of our view helpers so we would encourage you to review the files within the `www-root/core/library/Views/` directory for more information. Developer Tip: `HTMLTemplate.php` is an especially interesting feature.
 
-You will notice that if you visit [http://entrada-1x-me.dev/sandbox](http://entrada-1x-me.dev/sandbox) in your web browser that you will now see a PHP error. That is due to the fact that we are using **view helpers** on lines 30 - 31 of `www-root/core/modules/public/sandbox.inc.php` but have not yet created the files.
+You will notice that if you visit [http://entrada-1x-me.localhost/sandbox](http://entrada-1x-me.localhost/sandbox) in your web browser that you will now see a PHP error. That is due to the fact that we are using **view helpers** on lines 30 - 31 of `www-root/core/modules/public/sandbox.inc.php` but have not yet created the files.
 
 Proceed with creating the two new files to accommodate the `Views_Sandbox_Sidebar` and `Views_Sandbox_Form` view helpers:
 

--- a/docs/upgrade/1.10.md
+++ b/docs/upgrade/1.10.md
@@ -6,7 +6,7 @@ There were significant changes introduced to how authentication works in version
 
 ## API Filesystem Location
 
-The Entrada API application root lives in `www-root/core/api/` and is accessed via a bootstrap at `www-root/api/v2/index.php` (or `https://entrada-1x-me.dev/api/v2`).
+The Entrada API application root lives in `www-root/core/api/` and is accessed via a bootstrap at `www-root/api/v2/index.php` (or `http://entrada-1x-me.localhost/api/v2`).
 
 ## Settings File Changes
 
@@ -109,12 +109,12 @@ If you take a look at the HTML source code of Entrada ME 1.10's login page in th
 
 ```
 <script>
-    var ENTRADA_URL = 'http://entrada-1x-me.dev'; 
+    var ENTRADA_URL = 'http://entrada-1x-me.localhost'; 
     var ENTRADA_RELATIVE = ''; 
-    var TEMPLATE_URL = 'http://entrada-1x-me.dev/templates/default'; 
+    var TEMPLATE_URL = 'http://entrada-1x-me.localhost/templates/default'; 
     var TEMPLATE_RELATIVE = '/templates/default';
     var JWT = '';
-    var API_URL = 'http://entrada-1x-me.dev/api/v2';
+    var API_URL = 'http://entrada-1x-me.localhost/api/v2';
 </script>
 ```
 

--- a/docs/upgrade/1.11.md
+++ b/docs/upgrade/1.11.md
@@ -4,7 +4,7 @@ This documentation will serve as a help guide for developers seeking to upgrade 
 
 ## Entrada API Filesystem Location
 
-There was a relatively significant change to how the new RESTful Entrada API is loaded into the application in this release. This codebase, formerly located in `www-root/core/api`, is now a separate Git repository available from [entrada-1x-api](https://github.com/EntradaProject/entrada-1x-api) and is loaded into the codebase as a Composer dependency. The new filesystem location is `www-root/core/library/vendor/entradapackages/entrada-1x-api`, but the API is still accessed via URL at `https://entrada-1x-me.dev/api/v2`.
+There was a relatively significant change to how the new RESTful Entrada API is loaded into the application in this release. This codebase, formerly located in `www-root/core/api`, is now a separate Git repository available from [entrada-1x-api](https://github.com/EntradaProject/entrada-1x-api) and is loaded into the codebase as a Composer dependency. The new filesystem location is `www-root/core/library/vendor/entradapackages/entrada-1x-api`, but the API is still accessed via URL at `http://entrada-1x-me.localhost/api/v2`.
 
 Further documentation on optimal deployment strategies is forthcoming. 
 

--- a/resources/docker/README.md
+++ b/resources/docker/README.md
@@ -10,28 +10,40 @@ Developers using Docker don’t have to install and configure complex databases 
 
 ## Prerequisites
 
-1. You must have Docker installed on your local development machine. The simplest way to install everything is to use Docker Community Edition. You should also install Kitematic (GUI):
+1. You must have Docker for Mac or Docker for Windows installed on your local development machine. The simplest way to install everything is to use Docker Community Edition. You should also install Kitematic (GUI):
 
     https://www.docker.com/community-edition
-2. You must have the Entrada ME Git repository cloned to `~/Sites/entrada-1x-me.dev`.
+2. You must have the Entrada ME Git repository cloned to `~/Sites/entrada-1x-me.localhost`.
 3. You must edit your local `hosts` file and add each hostname you would like to use. For example:
     ```
-    127.0.0.1   entrada-1x-me.dev
+    127.0.0.1   entrada-1x-me.localhost
     ```
     
 ## Usage
 
 ### macOS
 
-```
-mkdir ~/Data
-cd ~/Documents
-git clone git@github.com:EntradaProject/entrada-1x-docs.git
-cd ~/Documents/entrada-1x-docs/resources/docker
-docker-compose up -d
-```
+1. Launch Terminal.app and run the following commands:
+    ```
+    cd ~/Documents
+    git clone git@github.com:EntradaProject/entrada-1x-docs.git
+    cd ~/Documents/entrada-1x-docs/resources/docker
+    docker-compose up -d
+    ```
 
-You can connect to the terminal of your new container by typing:
+### Windows 10
+
+1. Launch the **Git Bash** application and run the following commands:
+    ```
+    cd ~/Documents
+    git clone git@github.com:EntradaProject/entrada-1x-docs.git
+    cd ~/Documents/entrada-1x-docs/resources/docker
+    docker-compose up -d
+    ```
+
+## Connecting
+
+You can connect to the terminal of your new container by typing the following in Terminal or Git Bash:
 
 ```
 docker exec -it entrada-developer bash

--- a/resources/docker/README.md
+++ b/resources/docker/README.md
@@ -13,7 +13,7 @@ Developers using Docker don’t have to install and configure complex databases 
 1. You must have Docker for Mac or Docker for Windows installed on your local development machine. The simplest way to install everything is to use Docker Community Edition. You should also install Kitematic (GUI):
 
     https://www.docker.com/community-edition
-2. You must have the Entrada ME Git repository cloned to `~/Sites/entrada-1x-me.localhost`.
+2. You must have the Entrada ME Git repository cloned to `~/Sites/entrada-1x-me`.
 3. You must edit your local `hosts` file and add each hostname you would like to use. For example:
     ```
     127.0.0.1   entrada-1x-me.localhost

--- a/resources/docker/docker-compose.yml
+++ b/resources/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  web:
+  entrada:
     build: entrada
     container_name: entrada-developer
     ports:

--- a/resources/docker/docker-compose.yml
+++ b/resources/docker/docker-compose.yml
@@ -13,7 +13,10 @@ services:
             - ~/Sites:/var/www/vhosts
             - ./entrada/apache/vhosts.d:/etc/httpd/vhosts.d
         secrets:
-            - ssh_private_key
+            - source: ssh_private_key
+              uid: '0'
+              gid: '0'
+              mode: 0400
         restart: always
 volumes:
     mariadb_data:

--- a/resources/docker/docker-compose.yml
+++ b/resources/docker/docker-compose.yml
@@ -7,7 +7,6 @@ services:
             - 80:80
             - 443:443
             - 3306:3306
-            - 4444:4444
         volumes:
             - mariadb_data:/var/lib/mysql
             - ~/Sites:/var/www/vhosts

--- a/resources/docker/docker-compose.yml
+++ b/resources/docker/docker-compose.yml
@@ -1,17 +1,22 @@
-version: '3'
+version: '3.4'
 services:
-  entrada:
-    build: entrada
-    container_name: entrada-developer
-    ports:
-      - 80:80
-      - 443:443
-      - 3306:3306
-      - 4444:4444
-    volumes:
-      - mariadb_data:/var/lib/mysql
-      - ~/Sites:/var/www/vhosts
-      - ./entrada/apache/vhosts.d:/etc/httpd/vhosts.d
-    restart: always
+    entrada:
+        build: entrada
+        container_name: entrada-developer
+        ports:
+            - 80:80
+            - 443:443
+            - 3306:3306
+            - 4444:4444
+        volumes:
+            - mariadb_data:/var/lib/mysql
+            - ~/Sites:/var/www/vhosts
+            - ./entrada/apache/vhosts.d:/etc/httpd/vhosts.d
+        secrets:
+            - ssh_private_key
+        restart: always
 volumes:
-        mariadb_data:
+    mariadb_data:
+secrets:
+    ssh_private_key:
+        file: ~/.ssh/id_rsa

--- a/resources/docker/entrada/Dockerfile
+++ b/resources/docker/entrada/Dockerfile
@@ -99,6 +99,7 @@ RUN gem install gnm-caplock
 EXPOSE 80
 EXPOSE 443
 EXPOSE 3306
+EXPOSE 4444
 
 # Copy Supervisor configuration.
 COPY supervisor/supervisord.conf /etc/supervisord.conf

--- a/resources/docker/entrada/Dockerfile
+++ b/resources/docker/entrada/Dockerfile
@@ -46,24 +46,26 @@ RUN yum -y install git \
                 openssl \
                 httpd \
                 mod_ssl \
-                php56u \
-                php56u-mcrypt \
-                php56u-gd \
-                php56u-devel \
-                php56u-mysql \
-                php56u-intl \
-                php56u-mbstring \
-                php56u-pecl-xdebug \
-                php56u-bcmath \
-                php56u-ldap \
-                php56u-imap \
-                php56u-pspell \
-                php56u-soap \
-                php56u-xmlrpc \
-                php56u-tidy \
-                php56u-opcache \
-                mariadb-client \
-                mariadb-server
+                mod_php71u \
+                php71u-cli \
+                php71u-mcrypt \
+                php71u-gd \
+                php71u-devel \
+                php71u-mysqlnd \
+                php71u-intl \
+                php71u-mbstring \
+                php71u-pecl-xdebug \
+                php71u-bcmath \
+                php71u-ldap \
+                php71u-imap \
+                php71u-pspell \
+                php71u-soap \
+                php71u-xmlrpc \
+                php71u-tidy \
+                php71u-opcache \
+                php71u-json \
+                mariadb101u \
+                mariadb101u-server
 
 # Update PHP's configuration
 RUN sed -i 's@;date.timezone =@date.timezone = '"$TZ"'@g' /etc/php.ini

--- a/resources/docker/entrada/Dockerfile
+++ b/resources/docker/entrada/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:centos7
 
-LABEL maintainer "Matt Simpson <simpson@queensu.ca>"
+LABEL maintainer="Matt Simpson <simpson@queensu.ca>"
 
 # You can connect to a bash shell on entrada-developer by typing:
 # docker exec -it entrada-developer bash
@@ -28,7 +28,6 @@ RUN easy_install supervisor
 # Install Entrada Developer dependancies.
 RUN yum -y install git \
                 htmldoc \
-                wkhtmltopdf \
                 curl \
                 wget \
                 unzip \
@@ -66,6 +65,9 @@ RUN yum -y install git \
                 php71u-json \
                 mariadb101u \
                 mariadb101u-server
+
+# Install wkhtmltopdf from the binary package because the yum package provided by EPEL is broken.
+RUN curl -SL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz | tar -xJC /root && cp /root/wkhtmltox/bin/* /usr/bin
 
 # Update PHP's configuration
 RUN sed -i 's@;date.timezone =@date.timezone = '"$TZ"'@g' /etc/php.ini
@@ -109,5 +111,16 @@ COPY mariadb/entrada.cnf /etc/my.cnf.d
 COPY mariadb/entrada.sql /tmp
 COPY mariadb/mariadb-start.sh /usr/bin
 RUN chmod +x /usr/bin/mariadb-start.sh
+
+# Add github.com to your known_hosts file.
+RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh && ssh-keyscan github.com > /root/.ssh/known_hosts
+
+# At this time there is no good way of automatically getting your SSH private key
+# into the container. Most say it's a bad idea anyways, but most aren't using Docker
+# the way that we are (i.e. entrada-developer) for a local development environment.
+# Once this is running type this.
+# docker exec -it entrada-developer bash
+# cp /run/secrets/ssh_private_key /root/.ssh/id_rsa
+# chmod 600 /root/.ssh/id_rsa
 
 CMD ["/usr/bin/supervisord"]

--- a/resources/docker/entrada/Dockerfile
+++ b/resources/docker/entrada/Dockerfile
@@ -69,13 +69,18 @@ RUN yum -y install git \
 # Install wkhtmltopdf from the binary package because the yum package provided by EPEL is broken.
 RUN curl -SL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz | tar -xJC /root && cp /root/wkhtmltox/bin/* /usr/bin
 
-# Update PHP's configuration
+# Update PHP's configuration.
 RUN sed -i 's@;date.timezone =@date.timezone = '"$TZ"'@g' /etc/php.ini
 RUN sed -i 's@display_errors = Off@display_errors = On@g' /etc/php.ini
 RUN sed -i 's@error_reporting = E_ALL \& ~E_DEPRECATED \& ~E_STRICT@error_reporting = E_ALL \& ~E_NOTICE \& ~E_STRICT \& ~E_DEPRECATED@g' /etc/php.ini
 RUN sed -i 's@upload_max_filesize = 2M@upload_max_filesize = 512M@g' /etc/php.ini
 RUN sed -i 's@post_max_size = 8M@post_max_size = 512M@g' /etc/php.ini
 RUN sed -i 's@memory_limit = 128M@memory_limit = 512M@g' /etc/php.ini
+
+# Enable Xdebug's remote_debugging.
+# Important Note: Windows users must change docker.for.mac.host.internal to docker.for.win.host.internal
+RUN sed -i 's@;xdebug.remote_enable = 0@xdebug.remote_enable = 1@g' /etc/php.d/15-xdebug.ini
+RUN sed -i 's@;xdebug.remote_host = localhost@xdebug.remote_host = docker.for.mac.host.internal@g' /etc/php.d/15-xdebug.ini
 
 # Set the container volumes.
 VOLUME /var/lib/mysql
@@ -85,10 +90,10 @@ VOLUME /etc/httpd/vhosts.d
 # Install Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-# Tell Apache to include all of the virtual hosts
+# Tell Apache to include all of the virtual hosts.
 RUN echo "IncludeOptional vhosts.d/*.conf" >> /etc/httpd/conf/httpd.conf
 
-# Install PHPMyAdmin
+# Install PHPMyAdmin.
 RUN yum -y install phpmyadmin
 COPY apache/phpmyadmin.conf /etc/httpd/conf.d/phpmyadmin.conf
 
@@ -115,12 +120,26 @@ RUN chmod +x /usr/bin/mariadb-start.sh
 # Add github.com to your known_hosts file.
 RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh && ssh-keyscan github.com > /root/.ssh/known_hosts
 
-# At this time there is no good way of automatically getting your SSH private key
-# into the container. Most say it's a bad idea anyways, but most aren't using Docker
-# the way that we are (i.e. entrada-developer) for a local development environment.
-# Once this is running type this.
-# docker exec -it entrada-developer bash
-# cp /run/secrets/ssh_private_key /root/.ssh/id_rsa
-# chmod 600 /root/.ssh/id_rsa
+# In order to load your SSH private key into the Docker container for
+# use with deployments and cloning private repositories we use Docker's
+# "Secrets" feature. The secrets defined in the docker-compose.yml file
+# mount the hosts ~/.ssh/id_rsa file in read-only mode to
+# /run/secrets/ssh_private_key, which is then symlinked to /root/.ssh/id_rsa.
+#
+# Sadly this will not work for Windows users and you will need to remove
+# the automatically created symlink and copy the mounted file manually so
+# that you can set the appropriate permissions. See instructions below.
+
+RUN ln -s /run/secrets/ssh_private_key /root/.ssh/id_rsa
+
+# Instructions for Windows users to load your SSH private key:
+#
+# 1. Launch Windows PowerShell and type:
+#    docker exec -it entrada-developer bash
+#
+# 2. Replace the automatically created symlink with a copied file.
+#    rm /root/.ssh/id_rsa
+#    cp /run/secrets/ssh_private_key /root/.ssh/id_rsa
+#    chmod 0400 /root/.ssh/id_rsa
 
 CMD ["/usr/bin/supervisord"]

--- a/resources/docker/entrada/Dockerfile
+++ b/resources/docker/entrada/Dockerfile
@@ -94,8 +94,8 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN echo "IncludeOptional vhosts.d/*.conf" >> /etc/httpd/conf/httpd.conf
 
 # Install PHPMyAdmin.
-RUN yum -y install phpmyadmin
-COPY apache/phpmyadmin.conf /etc/httpd/conf.d/phpmyadmin.conf
+#RUN yum -y install phpmyadmin
+#COPY apache/phpmyadmin.conf /etc/httpd/conf.d/phpmyadmin.conf
 
 # Install Capistrano for deployment recipes.
 RUN gem install capistrano -v 2.15.9

--- a/resources/docker/entrada/apache/vhosts.d/.gitignore
+++ b/resources/docker/entrada/apache/vhosts.d/.gitignore
@@ -1,2 +1,2 @@
 *
-!entrada-1x-me.dev.conf
+!entrada-1x-me.localhost.conf

--- a/resources/docker/entrada/apache/vhosts.d/entrada-1x-me.localhost.conf
+++ b/resources/docker/entrada/apache/vhosts.d/entrada-1x-me.localhost.conf
@@ -7,8 +7,7 @@ EnableSendfile Off
     DocumentRoot /var/www/vhosts/entrada-1x-me/www-root
     <Directory "/var/www/vhosts/entrada-1x-me/www-root">
         Options FollowSymLinks
-        Order allow,deny
-        Allow from all
+        Require all granted
         AllowOverride all
     </Directory>
 </VirtualHost>

--- a/resources/docker/entrada/apache/vhosts.d/entrada-1x-me.localhost.conf
+++ b/resources/docker/entrada/apache/vhosts.d/entrada-1x-me.localhost.conf
@@ -2,10 +2,10 @@
 EnableSendfile Off
 
 <VirtualHost *:80>
-    ServerName entrada-1x-me.dev
+    ServerName entrada-1x-me.localhost
 
-    DocumentRoot /var/www/vhosts/entrada-1x-me.dev/www-root
-    <Directory "/var/www/vhosts/entrada-1x-me.dev/www-root">
+    DocumentRoot /var/www/vhosts/entrada-1x-me/www-root
+    <Directory "/var/www/vhosts/entrada-1x-me/www-root">
         Options FollowSymLinks
         Order allow,deny
         Allow from all

--- a/resources/docker/entrada/mariadb/entrada.cnf
+++ b/resources/docker/entrada/mariadb/entrada.cnf
@@ -5,3 +5,4 @@ expire_logs_days = 14
 query_cache_size = 32M
 ft_min_word_len = 3
 max_allowed_packet = 8388608
+sql_mode = ""

--- a/resources/docker/entrada/mariadb/entrada.cnf
+++ b/resources/docker/entrada/mariadb/entrada.cnf
@@ -1,8 +1,32 @@
 [mysqld]
-slow-query-log = 1
-long_query_time = 7
-expire_logs_days = 14
+
+# Innodb 
+innodb_buffer_pool_size = 1G                # main memory buffer of Innodb, very imporant
+innodb_log_file_size = 256M                 # transactional journal size 
+innodb_flush_method = O_DIRECT              # avoid double buffering with the OS
+innodb_flush_log_at_trx_commit = 2          # writes to OS, fsynced once per second
+innodb_buffer_pool_load_at_startup = on
+innodb_buffer_pool_dump_at_shutdown = on
+innodb_ft_min_token_size = 3
+
+# Basic Settings 
+thread_cache_size = 8
+table_open_cache = 4000
+table_definition_cache = 1500
 query_cache_size = 32M
-ft_min_word_len = 3
+query_cache_type = 1
 max_allowed_packet = 8388608
-sql_mode = ""
+sql_mode = "NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+
+# Replication
+server_id = 1012802 # the ip address of the server is a good idea.
+log_bin = /var/lib/mysql/mysql-bin
+expire_logs_days = 14
+sync_binlog = 4                             # 1: with every transaction 4 or 5: every 4th or 5th transaction.
+
+# Slow Query Logging / Tuning
+slow_query_log = on
+slow_query_log_file = /var/log/mysqld-slow-queries.log
+log_slow_verbosity = 'innodb,query_plan'
+long_query_time = 7
+performance_schema = on

--- a/resources/docker/entrada/mariadb/mariadb-start.sh
+++ b/resources/docker/entrada/mariadb/mariadb-start.sh
@@ -2,7 +2,7 @@
 
 if [ ! -f /var/lib/mysql/ibdata1 ]; then
 
-	/usr/bin/mysql_install_db
+	/usr/bin/mysql_install_db --user=mysql
 
 	/usr/bin/mysqld_safe &
 	sleep 5s

--- a/resources/vagrant/Vagrantfile
+++ b/resources/vagrant/Vagrantfile
@@ -78,8 +78,8 @@ Vagrant.configure("2") do |config|
 
     echo "Adding default hostnames to /etc/hosts..."
 
-    echo "127.0.0.1 entrada.dev" >> /etc/hosts
-    echo "127.0.0.1 entrada-1x-me.dev" >> /etc/hosts
+    echo "127.0.0.1 entrada.localhost" >> /etc/hosts
+    echo "127.0.0.1 entrada-1x-me.localhost" >> /etc/hosts
 
     echo "Setting the virtual machine timezone..."
 
@@ -173,7 +173,7 @@ Vagrant.configure("2") do |config|
     # NOTE change 'your-university-1x-me' to the name of your entrada git repository under ~/Sites
     # NOTE you may also have to change the apache ports if you have changed the port settings for Vagrant
     mkdir /etc/httpd/vhosts.d
-    curl -sk -o /etc/httpd/vhosts.d/entrada-1x-me.dev.conf https://raw.githubusercontent.com/EntradaProject/entrada-1x-docs/master/resources/vagrant/apache/vhosts.d/entrada-1x-me.dev.conf
+    curl -sk -o /etc/httpd/vhosts.d/entrada-1x-me.localhost.conf https://raw.githubusercontent.com/EntradaProject/entrada-1x-docs/master/resources/vagrant/apache/vhosts.d/entrada-1x-me.localhost.conf
     curl -sk -o /etc/httpd/conf.d/phpmyadmin.conf https://raw.githubusercontent.com/EntradaProject/entrada-1x-docs/master/resources/vagrant/apache/phpmyadmin.conf
 
     # Restart Apache
@@ -194,7 +194,7 @@ Vagrant.configure("2") do |config|
 
   # Stage 4 - This runs on EVERY boot, to make sure httpd starts (because it depends on the folders being mapped)
   config.vm.provision "shell", run: "always",  inline:  <<-SHELL3
-    if [ -f "/etc/httpd/conf.d/entrada-1x-me.dev.conf" ]
+    if [ -f "/etc/httpd/conf.d/entrada-1x-me.localhost.conf" ]
     then
       service httpd restart
     fi

--- a/resources/vagrant/apache/vhosts.d/entrada-1x-me.localhost.conf
+++ b/resources/vagrant/apache/vhosts.d/entrada-1x-me.localhost.conf
@@ -2,10 +2,10 @@
 EnableSendfile Off
 
 <VirtualHost *:80>
-    ServerName entrada-1x-me.dev
+    ServerName entrada-1x-me.localhost
 
-    DocumentRoot /var/www/vhosts/entrada-1x-me.dev/www-root
-    <Directory "/var/www/vhosts/entrada-1x-me.dev/www-root">
+    DocumentRoot /var/www/vhosts/entrada-1x-me/www-root
+    <Directory "/var/www/vhosts/entrada-1x-me/www-root">
         Options FollowSymLinks
         Order allow,deny
         Allow from all


### PR DESCRIPTION
## Google Chrome, Safari, and Firefox Requiring SSL/TLS for .dev Domains

On December 13th I sent a message to the developer mailing list bringing your attention to that fact that as of Chrome 63, Google is now requiring that SSL/TLS be enabled for all “.dev” gTLD domains. At this point, Safari (which uses Chrome's engine), and Firefox have also followed suit.

This unfortunately and frustratingly includes domains such as “entrada-1x-me.dev” that don’t route beyond localhost. For more information on the topic, see: https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts

We have this change in the `feature/docker-php71` branch of the `entrada-1x-docs` repository and are now applying this change to `master`.

In this branch we have:
* Upgraded PHP from 5.6 to 7.1.
* Upgraded MariaDB from 5.5 to 10.1.
* Made significant improvements to the `docker-compose.yml` and `Dockerfile` within the `resources/docker` directory.
    **Important Note:** Please make sure that you do a full `mysqldump` of your development databases if you'd like to keep them before rebuilding your Docker container with this image. We have changed the MariaDB storage directory from `~/Data` to use an internal Docker volume.
* Changed entrada-1x-me.dev to entrada-1x-me.localhost.
    **Important Note:** We recommend you switch all of your .dev domains to .localhost. We also recommend removing all extensions from the folders within  your ~/Sites folder.

    For example, this:
    ```
    ~/Sites/entrada-1x-me.dev
    ~/Sites/qu-entrada-1x-me.dev
    ~/Sites/wordpress.dev
    ```
    Would simply become:
    ```
    ~/Sites/entrada-1x-me
    ~/Sites/qu-entrada-1x-me
    ~/Sites/wordpress
    ```
    This will involve some updates do your Docker containers virtual host configuration files in `~/Documents/entrada-1x-docs/resources/docker/entrada/apache/vhosts.d`.

